### PR TITLE
Escape backslashes in string constants

### DIFF
--- a/lib/bq_fake_view.rb
+++ b/lib/bq_fake_view.rb
@@ -51,7 +51,7 @@ class BqFakeView
   def cast_to_sql_value(value, type)
     case value
     when String
-      %Q{"#{value.gsub(/"/, %q{\"})}"}
+      %Q{"#{value.gsub('\\', '\\\\\\\\').gsub(/"/, %q{\"})}"}
     when Numeric
       value.to_s
     when Time, Date


### PR DESCRIPTION
Without this fix, BQ responses `invalidQuery` error.
